### PR TITLE
Increased warnings for compile queue

### DIFF
--- a/slack.js
+++ b/slack.js
@@ -2,8 +2,30 @@
 const cron = require('node-cron')
 const { IncomingWebhook } = require('@slack/webhook');
 
+const ONE_X = '1x'
+const TWO_X = '2x'
+const FIVE_X = '5x'
+const TEN_X = '10x'
+
+const getNumberOfJobs = (limit, scale) => {
+  if (scale === ONE_X) {
+    return limit
+  } else if (scale === TWO_X) {
+    return limit * 2
+  } else if (scale === FIVE_X) {
+    return limit * 5
+  } else if (scale === TEN_X) {
+    return limit * 10
+  }
+}
+
 const createSlackCron = async (queues) => {
-  let notified = false
+  const notified = {
+    [ONE_X]: false,
+    [TWO_X]: false,
+    [FIVE_X]: false,
+    [TEN_X]: false,
+  }
 
   // Runs every 5 seconds
   await cron.schedule('*/5 * * * * *', async () => {
@@ -12,17 +34,25 @@ const createSlackCron = async (queues) => {
     if (queue && queue.IS_BEE) {
       const jobCounts = await queue.checkHealth();
       const limit = process.env.SLACK_CRON_LIMIT
+      const webhook = new IncomingWebhook(process.env.SLACK_WEBHOOK)
 
-      if (jobCounts.waiting < limit && notified) {
-        notified = false
+      const sendSlackWarning = async scale => {
+        const limitOfJobs = getNumberOfJobs(limit, scale)
+        console.log(jobCounts.waiting)
+        if (jobCounts.waiting < limitOfJobs && notified[scale]) {
+          await webhook.send({ text: `${limitOfJobs <= 100 ? '🥳 ' : ''}🔽 The compile queue has gone down. It now has less than ${limitOfJobs} jobs in it!` })
+          notified[scale] = false
+        }
+  
+        if (jobCounts.waiting >= limitOfJobs && !notified[scale]) {
+          await webhook.send({ text: `${limitOfJobs <= 100 ? '⚠️ ' : ''}🔼 The compile queue (editor saves backlog) has more than ${limitOfJobs} jobs waiting in it!` })
+          notified[scale] = true
+        }
       }
-
-      if (jobCounts.waiting >= limit && !notified) {
-        const webhook = new IncomingWebhook(process.env.SLACK_WEBHOOK)
-        await webhook.send({ text: `The compile queue has more than ${limit} jobs in it!` })
-        notified = true
-      }
+      
+      await Promise.all([sendSlackWarning(ONE_X), sendSlackWarning(TWO_X), sendSlackWarning(FIVE_X), sendSlackWarning(TEN_X)])
     }
+
     return
   });
 }

--- a/slack.js
+++ b/slack.js
@@ -38,7 +38,7 @@ const createSlackCron = async (queues) => {
 
       const sendSlackWarning = async scale => {
         const limitOfJobs = getNumberOfJobs(limit, scale)
-        console.log(jobCounts.waiting)
+
         if (jobCounts.waiting < limitOfJobs && notified[scale]) {
           await webhook.send({ text: `${limitOfJobs <= 100 ? '🥳 ' : ''}🔽 The compile queue has gone down. It now has less than ${limitOfJobs} jobs in it!` })
           notified[scale] = false


### PR DESCRIPTION
## Problem
Many in the company don't have high visibility into the compile queue. 

## Solution
Provide visibility by sending alerts to `#infrastructure` a little more frequently. This now will give us updates when the queue drops below the limits, as well as will warn us when we cross over 100 jobs, 200 jobs, 500 jobs, and 1,000 jobs.